### PR TITLE
fix genfromtxt bug in case one landmarks txt is provided

### DIFF
--- a/src/dataset.py
+++ b/src/dataset.py
@@ -191,8 +191,9 @@ class Dataset(torch.utils.data.Dataset):
                 return flist
 
             if os.path.isfile(flist):
+                landmark_file = np.genfromtxt(flist, dtype=np.str, encoding='utf-8')
                 try:
-                    return np.genfromtxt(flist, dtype=np.str, encoding='utf-8')
+                    return np.atleast_1d(landmark_file) # ndarray must have at least one dimension
                 except Exception as e:
                     print(e)
                     return [flist]


### PR DESCRIPTION
## Type of change

Bug fix

## Description

If a flist, contains just **one** file (.txt) path, the load_flist function in dataset.py returns a  0-dimensional numpy array. As a result, the `landmarks = np.genfromtxt(self.landmark_data[index])` command (line 105) in dataset.py fails, because a 0-dimensional numpy array can't be indexed.

To fix this, the load_flist function must return a numpy array with at least one dimension.
    